### PR TITLE
Fixes #12 Exclude functions with prefix `Must`

### DIFF
--- a/src/cmd/cgogen.go
+++ b/src/cmd/cgogen.go
@@ -507,7 +507,7 @@ func processFunc(fast *ast.File, fdecl *ast.FuncDecl, outFile *jen.File, dependa
 
 	funcName := fdecl.Name.Name
 
-	if !fdecl.Name.IsExported() {
+	if !fdecl.Name.IsExported() || strings.HasPrefix(funcName, "Must") {
 		applog("Skipping %v \n", funcName)
 		return
 	}


### PR DESCRIPTION
Fixes #12 

Changes:
- Exclude functions with prefix `Must`

Does this change need to mentioned in CHANGELOG.md?

No

